### PR TITLE
Refactor virus2 disease layer to genome-driven pathogen datums

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3169,6 +3169,7 @@
 #include "code\modules\virus2\antibodyanalyser.dm"
 #include "code\modules\virus2\centrifuge.dm"
 #include "code\modules\virus2\curer.dm"
+#include "code\modules\virus2\pathogen_model.dm"
 #include "code\modules\virus2\disease2.dm"
 #include "code\modules\virus2\diseasesplicer.dm"
 #include "code\modules\virus2\dishincubator.dm"

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -13,13 +13,36 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	var/antigen = list() // 16 bits describing the antigens, when one bit is set, a cure with that bit can dock here
 	var/max_stage = 4
 	var/list/affected_species = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_TAJARA, SPECIES_SWINE)
+	var/datum/pathogen_profile/profile
+	var/datum/pathogen_strain/strain
+	var/datum/pathogen_culture/culture
+	var/datum/pathogen_knowledge/knowledge
+	var/model_managed = FALSE
 
 /datum/disease2/disease/New(random_severity = 0)
+	profile = new
+	strain = new
+	culture = new
+	knowledge = new
+	model_managed = (src.type == /datum/disease2/disease)
 	uniqueID = rand(0, 10000)
+	strain.strain_id = uniqueID
 	if(random_severity)
 		makerandom(random_severity)
+	else if(model_managed)
+		strain.initialize_random()
+		rebuild_effects_from_strain()
+		sync_knowledge_from_model()
 
 /datum/disease2/disease/proc/update_disease()
+	if(model_managed)
+		strain.strain_id = uniqueID
+		strain.recompute_phenotype()
+		rebuild_effects_from_strain()
+		sync_knowledge_from_model()
+	else
+		sync_knowledge_from_effects()
+
 	var/list/datum/disease2/effect/effects_sorted = list() //Sort effects by stage
 
 	for(var/i in 1 to max_stage)
@@ -44,14 +67,11 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 		E.change_parent()
 
 /datum/disease2/disease/proc/makerandom(severity = 2)
-	var/list/excludetypes = list()
-	for(var/i = 1 ; i <= max_stage ; i++)
-		var/datum/disease2/effect/E = get_random_virus2_effect(i, severity, excludetypes)
-		E.stage = i
-		if(!E.allow_multiple)
-			excludetypes += E.type
-		effects += E
+	if(model_managed)
+		strain.initialize_random()
+		rebuild_effects_from_strain()
 	uniqueID = rand(0, 10000)
+	strain.strain_id = uniqueID
 	switch(severity)
 		if(1, 2)
 			infectionchance = rand(10, 20)
@@ -64,7 +84,51 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 
 	if(all_species.len)
 		affected_species = get_infectable_species()
+	sync_knowledge_from_model()
 	update_disease()
+
+/datum/disease2/disease/proc/rebuild_effects_from_strain()
+	if(!model_managed || !strain)
+		return
+	for(var/datum/disease2/effect/E in effects)
+		if(infected)
+			E.deactivate(infected)
+		effects -= E
+		qdel(E)
+	for(var/list/blueprint in strain.phenotype_blueprints)
+		var/effect_type = blueprint["effect_type"]
+		if(!effect_type)
+			continue
+		if(!can_add_symptom(effect_type))
+			continue
+		var/datum/disease2/effect/new_effect = new effect_type
+		new_effect.stage = blueprint["stage"]
+		new_effect.chance = blueprint["chance"]
+		new_effect.multiplier = blueprint["multiplier"]
+		effects += new_effect
+
+/datum/disease2/disease/proc/sync_knowledge_from_model()
+	if(!knowledge)
+		knowledge = new
+	knowledge.knowledge_level = 0
+	if(strain)
+		knowledge.confirm_hypothesis("Genome signature [strain.get_genome_signature()]")
+	knowledge.confirm_hypothesis("Transmission route [spreadtype]")
+	if(antigen && antigen.len)
+		knowledge.prove_vulnerability("Antigen docking: [antigens2string(antigen)]")
+	if(affected_species && affected_species.len)
+		knowledge.prove_vulnerability("Host range constrained to [jointext(affected_species, \", \")]")
+	if(knowledge.proven_vulnerabilities.len >= 2)
+		knowledge.knowledge_level = 3
+
+/datum/disease2/disease/proc/sync_knowledge_from_effects()
+	if(!knowledge)
+		knowledge = new
+	knowledge.knowledge_level = 1
+	if(effects.len)
+		knowledge.confirm_hypothesis("Phenotype observed: [effects.len] symptom(s)")
+	if(antigen && antigen.len)
+		knowledge.prove_vulnerability("Antigen docking: [antigens2string(antigen)]")
 
 /proc/get_infectable_species()
 	var/list/meat = list()
@@ -158,10 +222,19 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	BITSET(infected.hud_updateflag, STATUS_HUD)
 
 /datum/disease2/disease/proc/minormutate()
+	if(model_managed && strain)
+		strain.mutate_minor()
+		update_disease()
+		return
 	var/datum/disease2/effect/E = pick(effects)
-	E.minormutate()
+	if(E)
+		E.minormutate()
 
 /datum/disease2/disease/proc/mediummutate()
+	if(model_managed && strain)
+		strain.mutate_medium()
+		update_disease()
+		return 1
 	var/list/datum/disease2/effect/mutable_effects = list()
 	for(var/datum/disease2/effect/T in effects)
 		if(T.possible_mutations && T.possible_mutations.len)
@@ -187,6 +260,15 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	return 1
 
 /datum/disease2/disease/proc/majormutate(badness = VIRUS_ENGINEERED)
+	if(model_managed && strain)
+		strain.mutate_major()
+		if(prob(5))
+			antigen = list(pick(ALL_ANTIGENS))
+			antigen |= pick(ALL_ANTIGENS)
+		if(prob(5) && all_species.len)
+			affected_species = get_infectable_species()
+		update_disease()
+		return
 	uniqueID = rand(0,10000)
 	var/datum/disease2/effect/E = pick(effects)
 	var/list/exclude = list()
@@ -210,6 +292,11 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	update_disease()
 
 /datum/disease2/disease/proc/stageshift()
+	if(model_managed)
+		for(var/list/blueprint in strain.phenotype_blueprints)
+			blueprint["stage"] = min(max_stage, blueprint["stage"] + 1)
+		update_disease()
+		return
 	uniqueID = rand(0, 10000)
 	var/list/exclude = list()
 	for(var/datum/disease2/effect/D in effects)
@@ -228,7 +315,24 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 	disease.speed = speed
 	disease.antigen   = antigen
 	disease.uniqueID = uniqueID
+	disease.model_managed = model_managed
 	disease.affected_species = affected_species.Copy()
+	if(model_managed && strain)
+		disease.strain.segments = list()
+		for(var/datum/pathogen_genome_segment/segment in strain.segments)
+			var/datum/pathogen_genome_segment/new_segment = new
+			new_segment.slot = segment.slot
+			new_segment.allele = segment.allele
+			new_segment.expression = segment.expression
+			disease.strain.segments += new_segment
+		disease.strain.regulators = list()
+		for(var/datum/pathogen_regulator/regulator in strain.regulators)
+			var/datum/pathogen_regulator/new_regulator = new
+			new_regulator.id = regulator.id
+			new_regulator.target_trait = regulator.target_trait
+			new_regulator.modifier = regulator.modifier
+			disease.strain.regulators += new_regulator
+		disease.strain.recompute_phenotype()
 	for(var/datum/disease2/effect/effect in effects)
 		var/datum/disease2/effect/neweffect = new effect.type
 		neweffect.generate(effect.data)
@@ -236,6 +340,8 @@ LEGACY_RECORD_STRUCTURE(virus_records, virus_record)
 		neweffect.multiplier = effect.multiplier
 		neweffect.stage = effect.stage
 		disease.effects += neweffect
+	if(model_managed)
+		disease.rebuild_effects_from_strain()
 	disease.update_disease()
 	return disease
 
@@ -269,25 +375,35 @@ var/global/list/virusDB = list()
 		.= V.fields["name"]
 
 /datum/disease2/disease/proc/get_basic_info()
-	var/t = ""
+	var/list/symptoms = list()
 	for(var/datum/disease2/effect/E in effects)
-		t += ", [E.name]"
-	return "[name()] ([copytext(t,3)])"
+		symptoms += E.name
+	var/symptom_text = symptoms.len ? jointext(symptoms, ", ") : "No active phenotype"
+	return "[name()] ([symptom_text])"
 
 /datum/disease2/disease/proc/get_info()
+	var/knowledge_label = knowledge ? knowledge.get_level_label() : "Level 0 - Unknown"
+	var/species_text = affected_species && affected_species.len ? jointext(affected_species, ", ") : "Unknown"
 	var/r = {"
 	<small>Analysis determined the existence of a GNAv2-based viral lifeform.</small><br>
 	<u>Designation:</u> [name()]<br>
+	<u>Knowledge:</u> [knowledge_label]<br>
 	<u>Antigen:</u> [antigens2string(antigen)]<br>
 	<u>Transmitted By:</u> [spreadtype]<br>
 	<u>Rate of Progression:</u> [speed * 100]%<br>
-	<u>Species Affected:</u> [jointext(affected_species, ", ")]<br>
+	<u>Species Affected:</u> [species_text]<br>
 "}
+	if(strain && strain.metadata && strain.metadata["genome_signature"])
+		r += "<u>Genome Signature:</u> [strain.metadata[\"genome_signature\"]]<br>"
+	var/hypothesis_text = (knowledge && knowledge.confirmed_hypotheses.len) ? jointext(knowledge.confirmed_hypotheses, "; ") : "none"
+	var/vulnerability_text = (knowledge && knowledge.proven_vulnerabilities.len) ? jointext(knowledge.proven_vulnerabilities, "; ") : "none"
+	r += "<u>Confirmed Hypotheses:</u> [hypothesis_text]<br>"
+	r += "<u>Proven Vulnerabilities:</u> [vulnerability_text]<br>"
 
 	r += "<u>Symptoms:</u><br>"
 	for(var/datum/disease2/effect/E in effects)
 		r += "([E.stage]) [E.name]    "
-		r += "<small><u>Strength:</u> [E.multiplier >= 3 ? "Severe" : E.multiplier > 1 ? "Above Average" : "Average"]    "
+		r += "<small><u>Strength:</u> [E.multiplier >= 3 ? \"Severe\" : E.multiplier > 1 ? \"Above Average\" : \"Average\"]    "
 		r += "<u>Verosity:</u> [E.chance * 15]</small><br>"
 
 	return r

--- a/code/modules/virus2/pathogen_model.dm
+++ b/code/modules/virus2/pathogen_model.dm
@@ -1,0 +1,172 @@
+/datum/pathogen_profile
+	var/name = "Generic GNAv2 agent"
+	var/biology = "GNAv2"
+	var/list/species_targets = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_TAJARA, SPECIES_SWINE)
+	var/list/treatment_limitations = list("Requires antigen-matched antiviral support")
+
+/datum/pathogen_knowledge
+	var/knowledge_level = 0 // 0-3
+	var/list/confirmed_hypotheses = list()
+	var/list/proven_vulnerabilities = list()
+
+/datum/pathogen_knowledge/proc/confirm_hypothesis(text)
+	if(!text)
+		return
+	confirmed_hypotheses |= text
+	knowledge_level = min(3, max(knowledge_level, 1))
+
+/datum/pathogen_knowledge/proc/prove_vulnerability(text)
+	if(!text)
+		return
+	proven_vulnerabilities |= text
+	knowledge_level = min(3, max(knowledge_level, 2))
+
+/datum/pathogen_knowledge/proc/get_level_label()
+	switch(knowledge_level)
+		if(0)
+			return "Level 0 - Unknown"
+		if(1)
+			return "Level 1 - Hypothesis"
+		if(2)
+			return "Level 2 - Confirmed"
+		if(3)
+			return "Level 3 - Exhaustive"
+	return "Level ?"
+
+/datum/pathogen_culture
+	var/growth_index = 1.0
+	var/heterogeneity = 0.0
+	var/contamination = 0.0
+	var/list/pressure_history = list()
+
+/datum/pathogen_culture/proc/apply_pressure(pressure_label, delta_growth = 0, delta_heterogeneity = 0, delta_contamination = 0)
+	if(!pressure_label)
+		return
+	pressure_history += "[world.time]: [pressure_label]"
+	growth_index = max(0.2, growth_index + delta_growth)
+	heterogeneity = clamp(heterogeneity + delta_heterogeneity, 0, 1)
+	contamination = clamp(contamination + delta_contamination, 0, 1)
+
+/datum/pathogen_genome_segment
+	var/slot = 1
+	var/allele = "A"
+	var/expression = 1
+
+/datum/pathogen_regulator
+	var/id = "R1"
+	var/target_trait = "respiratory"
+	var/modifier = 1
+
+/datum/pathogen_strain
+	var/strain_id = 0
+	var/list/datum/pathogen_genome_segment/segments = list()
+	var/list/datum/pathogen_regulator/regulators = list()
+	var/list/phenotype_blueprints = list()
+	var/list/metadata = list()
+
+/datum/pathogen_strain/New()
+	..()
+	strain_id = rand(0, 10000)
+
+/datum/pathogen_strain/proc/initialize_random()
+	segments = list()
+	regulators = list()
+	var/segment_count = rand(6, 10)
+	for(var/i in 1 to segment_count)
+		var/datum/pathogen_genome_segment/segment = new
+		segment.slot = i
+		segment.allele = pick("A", "B", "C", "D", "E", "F")
+		segment.expression = rand(50, 150) / 100
+		segments += segment
+	var/regulator_count = rand(3, 6)
+	for(var/r in 1 to regulator_count)
+		var/datum/pathogen_regulator/regulator = new
+		regulator.id = "R[r]"
+		regulator.target_trait = pick("respiratory", "neurological", "digestive", "systemic")
+		regulator.modifier = rand(70, 140) / 100
+		regulators += regulator
+	recompute_phenotype()
+
+/datum/pathogen_strain/proc/get_trait_signal(target_trait)
+	var/signal = 0
+	for(var/datum/pathogen_genome_segment/segment in segments)
+		var/list/trait_map = pathogen_allele_traits(segment.allele)
+		signal += (trait_map[target_trait] || 0) * segment.expression
+	for(var/datum/pathogen_regulator/regulator in regulators)
+		if(regulator.target_trait == target_trait)
+			signal *= regulator.modifier
+	return signal
+
+/datum/pathogen_strain/proc/recompute_phenotype()
+	phenotype_blueprints = list()
+	var/list/rules = pathogen_effect_predicates()
+	for(var/list/rule in rules)
+		var/trait = rule["trait"]
+		if(get_trait_signal(trait) < rule["threshold"])
+			continue
+		var/list/blueprint = list(
+			"effect_type" = rule["effect_type"],
+			"stage" = rule["stage"],
+			"chance" = rule["chance"],
+			"multiplier" = rule["multiplier"]
+		)
+		phenotype_blueprints += list(blueprint)
+	metadata["genome_signature"] = get_genome_signature()
+
+/datum/pathogen_strain/proc/get_genome_signature()
+	var/list/signature = list()
+	for(var/datum/pathogen_genome_segment/segment in segments)
+		signature += "[segment.slot]:[segment.allele]-[segment.expression]"
+	for(var/datum/pathogen_regulator/regulator in regulators)
+		signature += "[regulator.id]:[regulator.target_trait]-[regulator.modifier]"
+	return jointext(signature, "|")
+
+/datum/pathogen_strain/proc/mutate_minor()
+	if(!segments.len)
+		return
+	var/datum/pathogen_genome_segment/segment = pick(segments)
+	segment.expression = clamp(segment.expression + rand(-20, 20) / 100, 0.4, 1.8)
+	recompute_phenotype()
+
+/datum/pathogen_strain/proc/mutate_medium()
+	if(!segments.len)
+		return
+	var/datum/pathogen_genome_segment/segment = pick(segments)
+	segment.allele = pick("A", "B", "C", "D", "E", "F")
+	recompute_phenotype()
+
+/datum/pathogen_strain/proc/mutate_major()
+	if(!regulators.len)
+		return
+	var/datum/pathogen_regulator/regulator = pick(regulators)
+	regulator.target_trait = pick("respiratory", "neurological", "digestive", "systemic")
+	regulator.modifier = rand(60, 170) / 100
+	recompute_phenotype()
+
+/proc/pathogen_allele_traits(allele)
+	switch(allele)
+		if("A")
+			return list("respiratory" = 1.2, "systemic" = 0.6)
+		if("B")
+			return list("digestive" = 1.1, "systemic" = 0.4)
+		if("C")
+			return list("neurological" = 1.3, "systemic" = 0.5)
+		if("D")
+			return list("respiratory" = 0.6, "digestive" = 0.9)
+		if("E")
+			return list("systemic" = 1.4)
+		if("F")
+			return list("neurological" = 0.7, "respiratory" = 0.7, "digestive" = 0.7)
+	return list()
+
+/proc/pathogen_effect_predicates()
+	return list(
+		list("effect_type" = /datum/disease2/effect/sneeze, "trait" = "respiratory", "threshold" = 2.2, "stage" = 1, "chance" = 35, "multiplier" = 1),
+		list("effect_type" = /datum/disease2/effect/cough, "trait" = "respiratory", "threshold" = 3.0, "stage" = 2, "chance" = 45, "multiplier" = 1),
+		list("effect_type" = /datum/disease2/effect/headache, "trait" = "neurological", "threshold" = 2.3, "stage" = 2, "chance" = 35, "multiplier" = 1),
+		list("effect_type" = /datum/disease2/effect/confusion, "trait" = "neurological", "threshold" = 3.1, "stage" = 3, "chance" = 30, "multiplier" = 2),
+		list("effect_type" = /datum/disease2/effect/stomach, "trait" = "digestive", "threshold" = 2.2, "stage" = 2, "chance" = 30, "multiplier" = 1),
+		list("effect_type" = /datum/disease2/effect/hungry, "trait" = "digestive", "threshold" = 3.0, "stage" = 3, "chance" = 35, "multiplier" = 2),
+		list("effect_type" = /datum/disease2/effect/drowsness, "trait" = "systemic", "threshold" = 2.0, "stage" = 1, "chance" = 45, "multiplier" = 1),
+		list("effect_type" = /datum/disease2/effect/shakey, "trait" = "systemic", "threshold" = 3.2, "stage" = 4, "chance" = 25, "multiplier" = 2)
+	)


### PR DESCRIPTION
### Motivation
- Replace the legacy effects-driven random symptom pipeline with a deterministic, genome-driven pathogen model so phenotypes derive from a genome and regulators instead of pure randomness.
- Separate concerns for profiling, genotype/phenotype, culture history and lab knowledge to support richer analysis and cleaner UI/reporting.
- Keep the public `/datum/disease2/disease` path as a thin facade so existing disease subtypes remain compatible while delegating generation and mutation to the new model.

### Description
- Added a new pathogen model in `code/modules/virus2/pathogen_model.dm` introducing `datum/pathogen_profile`, `datum/pathogen_strain`, `datum/pathogen_culture`, `datum/pathogen_knowledge`, plus `pathogen_genome_segment` and `pathogen_regulator` datums and the predicate set `pathogen_effect_predicates()` to derive phenotype deterministically.
- Represented genomes as 6–10 `segments` (alleles + expression) and 3–6 `regulators` (trait modifiers) inside `datum/pathogen_strain`, with `recompute_phenotype()` producing `phenotype_blueprints` consumed by the disease layer.
- Converted `/datum/disease2/disease` into a thin facade that stores `profile/strain/culture/knowledge`, delegates random generation and mutation to the strain (`initialize_random()`, `mutate_*()`), and rebuilds `effects` via `rebuild_effects_from_strain()` instead of the legacy random pipeline.
- Moved reporting to read from the new knowledge and phenotype: `get_basic_info`, `get_info` now include knowledge level, confirmed hypotheses, proven vulnerabilities and a genome signature when available, and `addToDB` now consumes the updated `get_info` output.
- Wired the new model into the build by including `code/modules/virus2/pathogen_model.dm` in `baystation12.dme` and added mapping of several predicate effect names to existing effect datums to stay compatible with current effect implementations.

### Testing
- Ran `git diff --check` to verify no obvious diff-check errors and it completed without reported errors.
- Checked effect references and predicate mapping with `rg` searches (ensuring predicate effect types exist in `code/modules/virus2/effects`) and validated outputs were found as expected.
- Verified the new model file was included in the compile list by inspecting `baystation12.dme` (the `#include "code/modules/virus2/pathogen_model.dm"` entry is present).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec66390dc8320ae246f59800aed25)